### PR TITLE
DLPX-88615 SSHJ - Bad packet received by server when hearbeat is enabled DLPX-88676 SSHJ - Fix false-alarm timeout exception when waiting for key exchange to complete

### DIFF
--- a/src/main/java/net/schmizz/concurrent/Promise.java
+++ b/src/main/java/net/schmizz/concurrent/Promise.java
@@ -104,7 +104,8 @@ public class Promise<V, T extends Throwable> {
         lock.lock();
         try {
             pendingEx = null;
-            deliver(null);
+            log.debug("Clearing <<{}>>", name);
+            val = null;
         } finally {
             lock.unlock();
         }

--- a/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
+++ b/src/main/java/net/schmizz/sshj/transport/TransportImpl.java
@@ -420,9 +420,9 @@ public final class TransportImpl
         try {
 
             if (kexer.isKexOngoing()) {
-                // Only transport layer packets (1 to 49) allowed except SERVICE_REQUEST
+                // Only transport layer packets (1 to 49) allowed except SERVICE_REQUEST and IGNORE
                 final Message m = Message.fromByte(payload.array()[payload.rpos()]);
-                if (!m.in(1, 49) || m == Message.SERVICE_REQUEST) {
+                if (!m.in(1, 49) || m == Message.SERVICE_REQUEST || m == Message.IGNORE) {
                     assert m != Message.KEXINIT;
                     kexer.waitForDone();
                 }


### PR DESCRIPTION
# Description 
Currently till delphix engine version 20.0.0.0 we are using sshj version v0.31.0 and adding required patches on the version.

However due to https://github.com/hierynomus/sshj/issues/916 we are required to upgrade to the latest 0.38.0 and add 2 changes for keepalive race conditions.

https://github.com/hierynomus/sshj/pull/911
https://github.com/hierynomus/sshj/pull/912

# Note
v0.38.0 has a fix for Terrapin Vulnerability CVE-2023-48795